### PR TITLE
remove unnecessary code

### DIFF
--- a/policy/modules/admin/bootloader.te
+++ b/policy/modules/admin/bootloader.te
@@ -259,8 +259,3 @@ optional_policy(`
 optional_policy(`
 	rpm_rw_pipes(bootloader_t)
 ')
-
-ifdef(`distro_gentoo',`
-	# Fix bug #537652 - grub2-mkconfig has search rights needed on current dir (usually user home dir)
-	userdom_search_user_home_dirs(bootloader_t)
-')

--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -173,7 +173,6 @@ allow portage_t self:process { setfscreate };
 # - kill for mysql merging, at least
 allow portage_t self:capability { kill setfcap sys_nice };
 allow portage_t self:netlink_route_socket create_netlink_socket_perms;
-dontaudit portage_t self:capability { dac_read_search };
 
 # user post-sync scripts
 can_exec(portage_t, portage_conf_t)


### PR DESCRIPTION
Regarding grub-mkconfig, this is no longer the case. There is dontaudit statement and config gets generated even without permisions for cwd.
Regarding portage, there is dac_read_search added to portage_t via if:
https://github.com/gentoo/hardened-refpolicy/blob/9a2384303ee211148b6a85974028743d5a482317/policy/modules/admin/portage.if#L75