### PR TITLE
netutils: /usr/bin/ss merged-usr

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -8,6 +8,7 @@
 /usr/bin/nmap		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/ping.* 	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/bin/send_arp	--	gen_context(system_u:object_r:ping_exec_t,s0)
+/usr/bin/ss		--	gen_context(system_u:object_r:ss_exec_t,s0)
 /usr/bin/tcpdump	--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/bin/tracepath.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
I don't know why /usr/sbin/ss is not in [upstream](https://github.com/SELinuxProject/refpolicy/blob/main/policy/modules/admin/netutils.fc), so I made a PR here.