### PR TITLE
small tweaks for systemd and zfs modules, files interfaces for later use

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7464,6 +7464,24 @@ interface(`files_create_all_runtime_sockets',`
 
 ########################################
 ## <summary>
+##     Create tmp_t sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_generic_tmp_sockets',`
+        gen_require(`
+                type tmp_t;
+        ')
+
+	allow $1 tmp_t:sock_file create_sock_file_perms;
+')
+
+########################################
+## <summary>
 ##     Delete all runtime sockets.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -762,6 +762,24 @@ interface(`files_mmap_read_all_files',`
 
 ########################################
 ## <summary>
+##	Read and memory map usr_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_mmap_read_usr_files',`
+        gen_require(`
+                type usr_t;
+        ')
+
+	mmap_read_files_pattern($1, usr_t, usr_t)
+')
+
+########################################
+## <summary>
 ##	Allow shared library text relocations in all files.
 ## </summary>
 ## <desc>

--- a/policy/modules/services/zfs.te
+++ b/policy/modules/services/zfs.te
@@ -135,6 +135,13 @@ userdom_use_user_terminals(zfs_t)
 
 zfs_rw_zpool_cache(zfs_t)
 
+# for reading compatibility file in /usr/share/zfs/compatibility.d/
+files_read_usr_files(zfs_t)
+files_mmap_read_usr_files(zfs_t)
+
+# auto-snapshots through systemd-timer not working without this
+allow zfs_t zfs_exec_t:file execute_no_trans;
+
 optional_policy(`
 	fstools_manage_runtime_files(zfs_t)
 	fstools_runtime_filetrans(zfs_t, dir, "blkid")

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1323,6 +1323,8 @@ fs_getattr_all_fs(systemd_networkd_t)
 fs_search_cgroup_dirs(systemd_networkd_t)
 fs_read_nsfs_files(systemd_networkd_t)
 fs_watch_memory_pressure(systemd_networkd_t)
+fs_list_tmpfs(systemd_networkd_t)
+fs_rw_cgroup_files(systemd_networkd_t)
 
 auth_use_nsswitch(systemd_networkd_t)
 


### PR DESCRIPTION
systemd-network-generator.service unit fails without:
  fs_list_tmpfs(systemd_networkd_t)

allow rw to
/sys/fs/cgroup/system.slice/systemd-networkd.service/memory.pressure
  fs_rw_cgroup_files(systemd_networkd_t)