### PR TITLE
xserver: add xdm user with role access to system_r and xdm_r

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -86,6 +86,10 @@ gen_tunable(xserver_object_manager, false)
 ## </desc>
 gen_tunable(xserver_allow_dri, false)
 
+# for sddm to use pam for greeter
+role xdm_r;
+allow system_r xdm_r;
+
 attribute x_domain;
 
 # X Events
@@ -169,6 +173,7 @@ fs_associate_tmpfs(xconsole_device_t)
 files_associate_tmp(xconsole_device_t)
 
 type xdm_t;
+role xdm_r types xdm_t;
 type xdm_exec_t;
 auth_login_pgm_domain(xdm_t)
 init_domain(xdm_t, xdm_exec_t)
@@ -891,6 +896,9 @@ manage_files_pattern(xserver_t, xdm_tmp_t, xdm_tmp_t)
 manage_lnk_files_pattern(xserver_t, xdm_tmp_t, xdm_tmp_t)
 manage_sock_files_pattern(xserver_t, xdm_tmp_t, xdm_tmp_t)
 
+# for sddm to use pam for greeter, sddm greeter needs execmod
+allow xdm_t xdm_tmpfs_t:file execmod;
+
 # Run Xorg.wrap
 can_exec(xserver_t, xserver_exec_t)
 
@@ -1091,3 +1099,6 @@ ifdef(`distro_gentoo',`
 		cgmanager_stream_connect(xdm_t)
 	')
 ')
+
+# for sddm to use pam for greeter
+gen_user(xdm,, xdm_r system_r, s0, s0)


### PR DESCRIPTION
Sync with upstream's xserver changes.

Previously reverted in https://github.com/gentoo/hardened-refpolicy/commit/dada9b3defc6c44e73d56adf245a5812c3f08404. The reasoning for the revert:
```
This commit added the sddm user to the xserver module.
This caused problems loading the xserver module if the user did not
exist on the system.
```
no longer applies, as upstream hit this issue here: https://github.com/SELinuxProject/refpolicy/issues/488 and resolved it here: https://github.com/SELinuxProject/refpolicy/commit/b6998e496d3ba98f6482355bce903c0f7c1a437d.

Fixes: https://github.com/gentoo/hardened-refpolicy/issues/7