### PR TITLE
tmpfiles: update path to openrc utilities

### DIFF
--- a/policy/modules/system/tmpfiles.fc
+++ b/policy/modules/system/tmpfiles.fc
@@ -7,4 +7,5 @@ ifndef(`init_systemd',`
 /usr/bin/tmpfiles				--	gen_context(system_u:object_r:tmpfiles_exec_t,s0)
 /usr/lib/rc/bin/checkpath			--	gen_context(system_u:object_r:tmpfiles_exec_t,s0)
 /usr/lib/rc/sh/tmpfiles\.sh			--	gen_context(system_u:object_r:tmpfiles_exec_t,s0)
-
+/usr/libexec/rc/bin/checkpath			--	gen_context(system_u:object_r:tmpfiles_exec_t,s0)
+/usr/libexec/rc/sh/tmpfiles\.sh			--	gen_context(system_u:object_r:tmpfiles_exec_t,s0)


### PR DESCRIPTION
openrc-0.56 changed the default path for rc utilities [1]. Still keep the old locations however, they don't hurt to have and can always be dropped in the future if desired.

[1] https://github.com/OpenRC/openrc/commit/7c31e504d5b48d688e5977f9616a1cd256310b03