### PR TITLE
matrixd: add filecon spec for gentoo configured builds

### DIFF
--- a/policy/modules/services/matrixd.fc
+++ b/policy/modules/services/matrixd.fc
@@ -4,3 +4,10 @@
 
 /var/lib/matrix-synapse(/.*)?		gen_context(system_u:object_r:matrixd_var_t,s0)
 /var/log/matrix-synapse(/.*)?		gen_context(system_u:object_r:matrixd_log_t,s0)
+
+ifdef(`distro_gentoo',`
+/etc/synapse(/.*)?			gen_context(system_u:object_r:matrixd_conf_t,s0)
+
+/var/lib/synapse(/.*)?			gen_context(system_u:object_r:matrixd_var_t,s0)
+/var/log/synapse(/.*)?			gen_context(system_u:object_r:matrixd_log_t,s0)
+')


### PR DESCRIPTION
Gentoo configures downstream[1][2] the configuration, log, and state directories to be different from the default upsteam. As this is a Gentoo modification, and not standard, gatekeep behind a build option for Gentoo.

[1] https://github.com/gentoo/gentoo/blob/094aa9559b11be900f0e3b4fcd005d72ba774070/net-im/synapse/files/synapse.service#L12
[2] https://github.com/gentoo/gentoo/blob/094aa9559b11be900f0e3b4fcd005d72ba774070/net-im/synapse/files/synapse.service#L19