### PR TITLE
openrc: adapt policy to use of seedrng

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -75,6 +75,9 @@ ifdef(`distro_redhat',`
 #
 /var/lib/random-seed	--	gen_context(system_u:object_r:init_random_seed_t,s0)
 /var/lib/systemd(/.*)?		gen_context(system_u:object_r:init_var_lib_t,s0)
+ifdef(`distro_gentoo',`
+/var/lib/seedrng(/.*)?		gen_context(system_u:object_r:init_random_seed_t,s0)
+')
 
 /run/initctl	-p	gen_context(system_u:object_r:initctl_t,s0)
 /run/kerneloops\.pid	--	gen_context(system_u:object_r:initrc_runtime_t,s0)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -991,6 +991,8 @@ ifdef(`distro_gentoo',`
 	files_manage_generic_locks(initrc_t)
 	files_manage_var_symlinks(initrc_t)
 	files_runtime_filetrans(initrc_t, initrc_state_t, dir, "openrc")
+	# TODO: Give seenrng its own domain. It is provided by openrc, but other things can use it, and regardless it would be good to confine it, even in early boot.
+	files_var_lib_filetrans(initrc_t, init_random_seed_t, dir, "seedrng")
 
 	# openrc uses tmpfs for its state data
 	fs_tmpfs_filetrans(initrc_t, initrc_state_t, { dir file fifo_file lnk_file })


### PR DESCRIPTION
openrc-0.45 changed the seeding mechanism for the random number generator [1]. The changed policy defines rules to enable accurate execution of seedrng at boot time.

[1] https://github.com/OpenRC/openrc/commit/076c2552aeff88a27fe275dfaae61dedf4bb4bd5