### PR TITLE
Revert "contrib: dirsrv: drop policy module"

### DIFF
--- a/doc/policy.xml
+++ b/doc/policy.xml
@@ -9072,6 +9072,109 @@ Domain allowed access
 </param>
 </interface>
 </module>
+<module name="dirsrv" filename="policy/modules/contrib/dirsrv.if">
+<summary>policy for dirsrv</summary>
+<interface name="dirsrv_domtrans" lineno="15">
+<summary>
+Execute a domain transition to run dirsrv.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed to transition.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_signal" lineno="38">
+<summary>
+Allow caller to signal dirsrv.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_signull" lineno="57">
+<summary>
+Send a null signal to dirsrv.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_manage_log" lineno="75">
+<summary>
+Allow a domain to manage dirsrv logs.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_manage_var_lib" lineno="95">
+<summary>
+Allow a domain to manage dirsrv /var/lib files.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_manage_var_run" lineno="113">
+<summary>
+Allow a domain to manage dirsrv /var/run files.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_pid_filetrans" lineno="132">
+<summary>
+Allow a domain to create dirsrv pid directories.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_read_var_run" lineno="150">
+<summary>
+Allow a domain to read dirsrv /var/run files.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_manage_config" lineno="168">
+<summary>
+Manage dirsrv configuration files.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+<interface name="dirsrv_read_share" lineno="187">
+<summary>
+Read dirsrv share files.
+</summary>
+<param name="domain">
+<summary>
+Domain allowed access.
+</summary>
+</param>
+</interface>
+</module>
 <module name="dracut" filename="policy/modules/contrib/dracut.if">
 <summary>Dracut initramfs creation tool</summary>
 <interface name="dracut_domtrans" lineno="13">

--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -855,6 +855,13 @@ bitcoin = module
 ceph = module
 
 # Layer: contrib
+# Module: dirsrv
+#
+# policy for dirsrv
+# 
+dirsrv = module
+
+# Layer: contrib
 # Module: dracut
 #
 # Dracut initramfs creation tool

--- a/policy/modules/contrib/dirsrv.fc
+++ b/policy/modules/contrib/dirsrv.fc
@@ -1,0 +1,12 @@
+/usr/share/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_share_t,s0)
+/usr/sbin/ns-slapd	--	gen_context(system_u:object_r:dirsrv_exec_t,s0)
+/usr/sbin/ldap-agent-bin	--	gen_context(system_u:object_r:dirsrv_snmp_exec_t,s0)
+
+/var/lib/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_var_lib_t,s0)
+/var/lock/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_var_lock_t,s0)
+/var/log/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_var_log_t,s0)
+/var/log/dirsrv/ldap-agent\.log	gen_context(system_u:object_r:dirsrv_snmp_var_log_t,s0)
+/run/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_runtime_t,s0)
+/run/ldap-agent\.pid	gen_context(system_u:object_r:dirsrv_snmp_runtime_t,s0)
+
+/etc/dirsrv(/.*)?	gen_context(system_u:object_r:dirsrv_config_t,s0)

--- a/policy/modules/contrib/dirsrv.if
+++ b/policy/modules/contrib/dirsrv.if
@@ -1,0 +1,195 @@
+## <summary>policy for dirsrv</summary>
+#
+# Provided by the 389-ds-base package
+
+########################################
+## <summary>
+##	Execute a domain transition to run dirsrv.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`dirsrv_domtrans',`
+	gen_require(`
+		type dirsrv_t, dirsrv_exec_t;
+	')
+
+	domain_auto_transition_pattern($1, dirsrv_exec_t, dirsrv_t)
+
+	allow dirsrv_t $1:fd use;
+	allow dirsrv_t $1:fifo_file rw_fifo_file_perms;
+	allow dirsrv_t $1:process sigchld;
+')
+
+
+########################################
+## <summary>
+##  Allow caller to signal dirsrv.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_signal',`
+	gen_require(`
+		type dirsrv_t;
+	')
+
+	allow $1 dirsrv_t:process signal;
+')
+
+
+########################################
+## <summary>
+##	Send a null signal to dirsrv.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_signull',`
+	gen_require(`
+		type dirsrv_t;
+	')
+
+	allow $1 dirsrv_t:process signull;
+')
+
+#######################################
+## <summary>
+##	Allow a domain to manage dirsrv logs.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`dirsrv_manage_log',`
+	gen_require(`
+		type dirsrv_var_log_t;
+	')
+
+	allow $1 dirsrv_var_log_t:dir manage_dir_perms;
+	allow $1 dirsrv_var_log_t:file manage_file_perms;
+	allow $1 dirsrv_var_log_t:fifo_file manage_fifo_file_perms;
+')
+
+#######################################
+## <summary>
+##	Allow a domain to manage dirsrv /var/lib files.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`dirsrv_manage_var_lib',`
+	gen_require(`
+		type dirsrv_var_lib_t;
+	')
+	allow $1 dirsrv_var_lib_t:dir manage_dir_perms;
+	allow $1 dirsrv_var_lib_t:file manage_file_perms;
+')
+
+#######################################
+## <summary>
+##	Allow a domain to manage dirsrv /var/run files.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`dirsrv_manage_var_run',`
+	gen_require(`
+		type dirsrv_runtime_t;
+	')
+	allow $1 dirsrv_runtime_t:dir manage_dir_perms;
+	allow $1 dirsrv_runtime_t:file manage_file_perms;
+	allow $1 dirsrv_runtime_t:sock_file manage_sock_file_perms;
+')
+
+######################################
+## <summary>
+##	Allow a domain to create dirsrv pid directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_pid_filetrans',`
+	gen_require(`
+		type dirsrv_runtime_t;
+	')
+	# Allow creating a dir in /var/run with this type
+	files_runtime_filetrans($1, dirsrv_runtime_t, dir)
+')
+
+#######################################
+## <summary>
+##	Allow a domain to read dirsrv /var/run files.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`dirsrv_read_var_run',`
+	gen_require(`
+		type dirsrv_runtime_t;
+	')
+	allow $1 dirsrv_runtime_t:dir list_dir_perms;
+	allow $1 dirsrv_runtime_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Manage dirsrv configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_manage_config',`
+	gen_require(`
+		type dirsrv_config_t;
+	')
+
+	allow $1 dirsrv_config_t:dir manage_dir_perms;
+	allow $1 dirsrv_config_t:file manage_file_perms;
+')
+
+########################################
+## <summary>
+##	Read dirsrv share files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_read_share',`
+	gen_require(`
+		type dirsrv_share_t;
+	')
+
+	allow $1 dirsrv_share_t:dir list_dir_perms;
+	allow $1 dirsrv_share_t:file read_file_perms;
+	allow $1 dirsrv_share_t:lnk_file read;
+')

--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -1,0 +1,206 @@
+policy_module(dirsrv,1.0.0)
+
+# Provided by the 389-ds-base package
+
+########################################
+#
+# Declarations
+#
+
+# main daemon
+type dirsrv_t;
+type dirsrv_exec_t;
+domain_type(dirsrv_t)
+init_daemon_domain(dirsrv_t, dirsrv_exec_t)
+
+# snmp subagent daemon
+type dirsrv_snmp_t;
+type dirsrv_snmp_exec_t;
+domain_type(dirsrv_snmp_t)
+init_daemon_domain(dirsrv_snmp_t, dirsrv_snmp_exec_t)
+
+# var/lib files
+type dirsrv_var_lib_t;
+files_type(dirsrv_var_lib_t)
+
+# log files
+type dirsrv_var_log_t;
+logging_log_file(dirsrv_var_log_t)
+
+# snmp log file
+type dirsrv_snmp_var_log_t;
+logging_log_file(dirsrv_snmp_var_log_t)
+
+# pid files
+type dirsrv_runtime_t alias dirsrv_var_run_t;
+files_runtime_file(dirsrv_runtime_t)
+
+# snmp pid file
+type dirsrv_snmp_runtime_t alias dirsrv_snmp_var_run_t;
+files_runtime_file(dirsrv_snmp_runtime_t)
+
+# lock files
+type dirsrv_var_lock_t;
+files_lock_file(dirsrv_var_lock_t)
+
+# config files
+type dirsrv_config_t;
+files_type(dirsrv_config_t)
+
+# tmp files
+type dirsrv_tmp_t;
+files_tmp_file(dirsrv_tmp_t)
+
+# semaphores
+type dirsrv_tmpfs_t;
+files_tmpfs_file(dirsrv_tmpfs_t)
+
+# shared files
+type dirsrv_share_t;
+files_type(dirsrv_share_t)
+
+########################################
+#
+# dirsrv local policy
+#
+
+# Some common macros
+files_read_etc_files(dirsrv_t)
+corecmd_search_bin(dirsrv_t)
+files_read_usr_symlinks(dirsrv_t)
+miscfiles_read_localization(dirsrv_t)
+dev_read_urand(dirsrv_t)
+libs_use_ld_so(dirsrv_t)
+libs_use_shared_libs(dirsrv_t)
+allow dirsrv_t self:fifo_file rw_inherited_fifo_file_perms;
+
+# process stuff
+allow dirsrv_t self:process { getsched setsched setfscreate signal_perms};
+allow dirsrv_t self:capability { sys_nice setuid setgid fsetid chown dac_override fowner };
+
+# semaphores
+allow dirsrv_t self:sem all_sem_perms;
+manage_files_pattern(dirsrv_t, dirsrv_tmpfs_t, dirsrv_tmpfs_t)
+fs_tmpfs_filetrans(dirsrv_t, dirsrv_tmpfs_t, file)
+
+# var/lib files for dirsrv
+manage_files_pattern(dirsrv_t, dirsrv_var_lib_t, dirsrv_var_lib_t)
+manage_dirs_pattern(dirsrv_t, dirsrv_var_lib_t, dirsrv_var_lib_t)
+files_var_lib_filetrans(dirsrv_t,dirsrv_var_lib_t, { file dir sock_file })
+
+# log files
+manage_files_pattern(dirsrv_t, dirsrv_var_log_t, dirsrv_var_log_t)
+manage_fifo_files_pattern(dirsrv_t, dirsrv_var_log_t, dirsrv_var_log_t)
+allow dirsrv_t dirsrv_var_log_t:dir { setattr };
+logging_log_filetrans(dirsrv_t,dirsrv_var_log_t,{ sock_file file dir })
+
+# pid files
+manage_files_pattern(dirsrv_t, dirsrv_runtime_t, dirsrv_runtime_t)
+files_runtime_filetrans(dirsrv_t, dirsrv_runtime_t, { file sock_file })
+
+# ldapi socket
+manage_sock_files_pattern(dirsrv_t, dirsrv_runtime_t, dirsrv_runtime_t)
+
+# lock files
+manage_files_pattern(dirsrv_t, dirsrv_var_lock_t, dirsrv_var_lock_t)
+manage_dirs_pattern(dirsrv_t, dirsrv_var_lock_t, dirsrv_var_lock_t)
+files_lock_filetrans(dirsrv_t, dirsrv_var_lock_t, { file })
+
+# config files
+manage_files_pattern(dirsrv_t, dirsrv_config_t, dirsrv_config_t)
+manage_dirs_pattern(dirsrv_t, dirsrv_config_t, dirsrv_config_t)
+
+# tmp files
+manage_files_pattern(dirsrv_t, dirsrv_tmp_t, dirsrv_tmp_t)
+manage_dirs_pattern(dirsrv_t, dirsrv_tmp_t, dirsrv_tmp_t)
+files_tmp_filetrans(dirsrv_t, dirsrv_tmp_t, { file dir })
+
+# system state
+fs_getattr_all_fs(dirsrv_t)
+kernel_read_system_state(dirsrv_t)
+
+# Networking basics
+sysnet_dns_name_resolve(dirsrv_t)
+corenet_all_recvfrom_unlabeled(dirsrv_t)
+corenet_all_recvfrom_netlabel(dirsrv_t)
+corenet_tcp_sendrecv_generic_if(dirsrv_t)
+corenet_tcp_sendrecv_generic_node(dirsrv_t)
+corenet_tcp_bind_all_nodes(dirsrv_t)
+corenet_tcp_bind_ldap_port(dirsrv_t)
+corenet_tcp_bind_all_rpc_ports(dirsrv_t)
+corenet_udp_bind_all_rpc_ports(dirsrv_t)
+corenet_tcp_connect_all_ports(dirsrv_t)
+corenet_sendrecv_ldap_server_packets(dirsrv_t)
+corenet_sendrecv_all_client_packets(dirsrv_t)
+allow dirsrv_t self:tcp_socket { create_stream_socket_perms };
+
+# Init script handling
+init_use_fds(dirsrv_t)
+init_use_script_ptys(dirsrv_t)
+domain_use_interactive_fds(dirsrv_t)
+
+optional_policy(`
+	# kerberos config for SASL GSSAPI
+	kerberos_read_config(dirsrv_t)
+	kerberos_dontaudit_write_config(dirsrv_t)
+')
+
+########################################
+#
+# dirsrv-snmp local policy
+#
+
+# Some common macros
+files_read_etc_files(dirsrv_snmp_t)
+miscfiles_read_localization(dirsrv_snmp_t)
+libs_use_ld_so(dirsrv_snmp_t)
+libs_use_shared_libs(dirsrv_snmp_t)
+dev_read_rand(dirsrv_snmp_t)
+dev_read_urand(dirsrv_snmp_t)
+files_read_usr_files(dirsrv_snmp_t)
+fs_getattr_tmpfs(dirsrv_snmp_t)
+fs_search_tmpfs(dirsrv_snmp_t)
+allow dirsrv_snmp_t self:fifo_file rw_inherited_fifo_file_perms;
+sysnet_read_config(dirsrv_snmp_t)
+sysnet_dns_name_resolve(dirsrv_snmp_t)
+
+# Net-SNMP agentx tcp socket
+corenet_tcp_connect_agentx_port(dirsrv_snmp_t)
+
+# Net-SNMP persistent data file
+files_manage_var_files(dirsrv_snmp_t)
+
+# stats file semaphore
+rw_files_pattern(dirsrv_snmp_t, dirsrv_tmpfs_t, dirsrv_tmpfs_t)
+
+# stats file
+read_files_pattern(dirsrv_snmp_t, dirsrv_runtime_t, dirsrv_runtime_t)
+
+# process stuff
+allow dirsrv_snmp_t self:capability { dac_override dac_read_search };
+
+# config file
+read_files_pattern(dirsrv_snmp_t, dirsrv_config_t, dirsrv_config_t)
+
+# pid file
+manage_files_pattern(dirsrv_snmp_t, dirsrv_snmp_runtime_t, dirsrv_snmp_runtime_t)
+files_runtime_filetrans(dirsrv_snmp_t, dirsrv_snmp_runtime_t, { file sock_file })
+search_dirs_pattern(dirsrv_snmp_t, dirsrv_runtime_t, dirsrv_runtime_t)
+
+# log file
+manage_files_pattern(dirsrv_snmp_t, dirsrv_var_log_t, dirsrv_snmp_var_log_t)
+filetrans_pattern(dirsrv_snmp_t, dirsrv_var_log_t, dirsrv_snmp_var_log_t, file)
+
+# Init script handling
+init_use_fds(dirsrv_snmp_t)
+init_use_script_ptys(dirsrv_snmp_t)
+domain_use_interactive_fds(dirsrv_snmp_t)
+
+optional_policy(`
+	# Net-SNMP /var/lib files (includes agentx unix domain socket)
+	snmp_dontaudit_read_snmp_var_lib_files(dirsrv_snmp_t)
+	snmp_dontaudit_write_snmp_var_lib_files(dirsrv_snmp_t)
+	snmp_append_var_lib_files(dirsrv_snmp_t)
+	snmp_stream_connect(dirsrv_snmp_t)
+')
+


### PR DESCRIPTION
This reverts commit 68ce6d329296cbaf7cd1233eaa305da7ef46314a.

Turns out it _is_ actually used in ::gentoo, by net-nds/389-ds-base[1].

[1] https://github.com/gentoo/gentoo/blob/edb62aecc321421e80177f7d95c63070d061f38a/net-nds/389-ds-base/389-ds-base-3.0.6.ebuild#L199

Closes: https://bugs.gentoo.org/968398